### PR TITLE
Read telegram from UARTDevice instead of Serial

### DIFF
--- a/obis.h
+++ b/obis.h
@@ -1,0 +1,117 @@
+
+/* 
+Adapted code based on response from VS Code Copilot 20241020.
+Prompt "Give a code example for esphome to parse obis
+	output code into key value unit and name the obis codes correctly"
+*/
+
+#define MAX_OBIS_CODES 20
+#define MAX_OBIS_LENGTH 20
+#define MAX_NAME_LENGTH 50
+#define MAX_UNIT_LENGTH 10
+#define MAX_VALUE_LENGTH 50
+
+typedef struct {
+    char obis_code[MAX_OBIS_LENGTH];
+    char name[MAX_NAME_LENGTH];
+    char value[MAX_VALUE_LENGTH];
+    char unit[MAX_UNIT_LENGTH];
+} OBISData;
+
+// Define a dictionary to map OBIS codes to their names
+typedef struct {
+    char obis_code[MAX_OBIS_LENGTH];
+    char name[MAX_NAME_LENGTH];
+} OBISDictionary;
+
+OBISDictionary obis_dict[] = {
+        {"6.8", "Cumulative Energy (MWh)"},
+        {"6.26", "Cumulative Volume (m3)"},
+        {"9.21", "Serial Number"},
+        {"6.4", "Current Power (kW)"},
+        {"6.27", "Flow Rate (m3ph)"},
+        {"6.29", "Temperature C (Flow)"},
+        {"6.28", "Temperature C (Return)"},
+        {"6.30", "Temperature C (Difference)"},
+        {"6.26*01", "Volume (Tariff 1)"},
+        {"6.8*01", "Energy (Tariff 1)"},
+        {"F", "Firmware Version"},
+        {"9.20", "Serial Number"},
+        {"6.35", "Flow Rate (m)"},
+        {"6.6", "Power max (kW)"},
+        {"6.6*01", "Power max (Tariff 1)"},
+        {"6.33", "Flow Rate (m3ph)"},
+        {"9.4", "Temperature (C)"},
+        {"6.31", "Operating Hours (h)"},
+        {"6.32", "Downtime (h)"},
+        {"9.22", "Status"},
+        {"9.6", "Extended Status"},
+        {"9.7", "Error Code"},
+        {"6.32*01", "Downtime (Tariff 1)"},
+        {"6.36", "Date and Time"},
+        {"6.33*01", "Flow Rate (Tariff 1)"},
+        {"6.8.1", "Energy Phase 1"},
+        {"6.8.2", "Energy Phase 2"},
+        {"6.8.3", "Energy Phase 3"},
+        {"6.8.4", "Energy Phase 4"},
+        {"6.8.5", "Energy Phase 5"},
+        {"6.8.1*01", "Energy Phase 1 (Tariff 1)"},
+        {"6.8.2*01", "Energy Phase 2 (Tariff 1)"},
+        {"6.8.3*01", "Energy Phase 3 (Tariff 1)"},
+        {"6.8.4*01", "Energy Phase 4 (Tariff 1)"},
+        {"6.8.5*01", "Energy Phase 5 (Tariff 1)"},
+    };
+
+const char* get_obis_name(const char* obis_code) {
+    for (int i = 0; i < sizeof(obis_dict) / sizeof(obis_dict[0]); i++) {
+        if (strcmp(obis_dict[i].obis_code, obis_code) == 0) {
+            return obis_dict[i].name;
+        }
+    }
+    return "Unknown";
+}
+
+void parse_obis(const char* obis_string, OBISData* parsed_data, int* parsed_count) {
+    const char* ptr = obis_string;
+    *parsed_count = 0;
+
+    while (*ptr != '\0' && *parsed_count < MAX_OBIS_CODES) {
+        OBISData* data = &parsed_data[*parsed_count];
+	while (*ptr == 0xa || *ptr == 0x0d) ptr++; // Skip newlines
+        const char* obis_code_end = strchr(ptr, '(');
+        if (obis_code_end == NULL) break;
+
+        strncpy(data->obis_code, ptr, obis_code_end - ptr);
+        data->obis_code[obis_code_end - ptr] = '\0';
+
+        const char* value_start = obis_code_end + 1;
+        const char* value_end = strchr(value_start, ')');
+        if (value_end == NULL) break;
+
+        strncpy(data->value, value_start, value_end - value_start);
+        data->value[value_end - value_start] = '\0';
+
+        char* unit_start = strchr(data->value, '*');
+        if (unit_start != NULL) {
+            *unit_start = '\0';
+            strncpy(data->unit, unit_start + 1, MAX_UNIT_LENGTH - 1);
+        } else {
+            data->unit[0] = '\0';
+        }
+
+        strncpy(data->name, get_obis_name(data->obis_code), MAX_NAME_LENGTH - 1);
+
+        ptr = value_end + 1;
+        (*parsed_count)++;
+    }
+}
+
+void print_parsed_data(const OBISData* parsed_data, int parsed_count) {
+    for (int i = 0; i < parsed_count; i++) {
+        ESP_LOGD("OBIS", "OBIS Code: %s", parsed_data[i].obis_code);
+        ESP_LOGD("OBIS", "Name: %s", parsed_data[i].name);
+        ESP_LOGD("OBIS", "Value: %s", parsed_data[i].value);
+        ESP_LOGD("OBIS", "Unit: %s", parsed_data[i].unit);
+        ESP_LOGD("OBIS", "");
+    }
+}

--- a/uh50reader.h
+++ b/uh50reader.h
@@ -21,15 +21,15 @@
 
 #include "esphome.h"
 
-#define BUF_SIZE 1500
-#define WAIT_TIME 10
+#define BUF_SIZE 2500
+#define WAIT_TIME 1
 
 byte data_cmd[] = { 
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x2F, 0x3F, 0x21, 0x0D, 0x0A
+  '/',  '#' , '!', 0x0D, 0x0A
 };
 
 // Landis & Gyr EN 61107 mode B protocol
@@ -40,12 +40,6 @@ byte data_cmd[] = {
 // https://github.com/lvzon/dsmr-p1-parser/blob/master/doc/IEC-62056-21-notes.md
 // http://womp3-14.vijfwal.nl/p2013c.html
 
-class ParsedMessage {
-  public:
-    double cumulativeActiveImport;
-    double cumulativeVolume;
-};
-
 class UH50Reader : public Component, public UARTDevice, public CustomAPIDevice {
   const char* DELIMITERS = "(*";
   UARTDevice uart_out;
@@ -55,6 +49,11 @@ class UH50Reader : public Component, public UARTDevice, public CustomAPIDevice {
   public:
     Sensor *cumulativeActiveImport = new Sensor();
     Sensor *cumulativeVolume = new Sensor();
+    Sensor *currentPower = new Sensor();
+    Sensor *flowRate = new Sensor();
+    Sensor *temperatureFlow = new Sensor();
+    Sensor *temperatureReturn = new Sensor();
+    Sensor *temperatureDiff = new Sensor();
 
     UH50Reader(UARTComponent *uart_in, UARTComponent *uart_out) : UARTDevice(uart_in), uart_out(uart_out) { }
 
@@ -80,42 +79,25 @@ class UH50Reader : public Component, public UARTDevice, public CustomAPIDevice {
     }
 
   private:
-    char* strtok_single (char * str, char const * delims) {
-      static char  * src = NULL;
-      char  *  p,  * ret = 0;
 
-      if (str != NULL)
-        src = str;
+    void publishSensors(OBISData *od, int count) {
 
-      if (src == NULL)
-        return NULL;
-
-      if ((p = strpbrk (src, delims)) != NULL) {
-        *p  = 0;
-        ret = src;
-        src = ++p;
-
-      } else if (*src) {
-        ret = src;
-        src = NULL;
+      for (int i=0; i < count; i++) {
+	if (!strcmp(od[i].obis_code, "6.8"))
+          cumulativeActiveImport->publish_state(atof(od[i].value));
+	else if (!strcmp(od[i].obis_code, "6.26"))
+          cumulativeVolume->publish_state(atof(od[i].value));
+	else if (!strcmp(od[i].obis_code, "6.4"))
+          currentPower->publish_state(atof(od[i].value));
+	else if (!strcmp(od[i].obis_code, "6.27"))
+          flowRate->publish_state(atof(od[i].value));
+	else if (!strcmp(od[i].obis_code, "6.29"))
+          temperatureFlow->publish_state(atof(od[i].value));
+	else if (!strcmp(od[i].obis_code, "6.28"))
+          temperatureReturn->publish_state(atof(od[i].value));
+	else if (!strcmp(od[i].obis_code, "6.30"))
+          temperatureDiff->publish_state(atof(od[i].value));
       }
-
-      return ret;
-    }
-
-    void parseRow(ParsedMessage* parsed, char* obis_code, char* value) {
-      if (strncmp(obis_code, "6.8", 6) == 0) {
-        parsed->cumulativeActiveImport = atof(value) * 1000;
-
-      } else if (strncmp(obis_code, "6.26", 6) == 0) {
-        parsed->cumulativeVolume = atof(value);
-
-      }
-    }
-
-    void publishSensors(ParsedMessage* parsed) {
-      cumulativeActiveImport->publish_state(parsed->cumulativeActiveImport);
-      cumulativeVolume->publish_state(parsed->cumulativeVolume);
     }
 
     void sendDataCmd() {
@@ -126,7 +108,7 @@ class UH50Reader : public Component, public UARTDevice, public CustomAPIDevice {
     }
 
     void readTelegram() {
-      ParsedMessage parsed = ParsedMessage();
+      OBISData obisdata[MAX_OBIS_CODES];
       
       bool publish=false;
       // fast forward until we find the STX byte (start-of-text)
@@ -141,37 +123,14 @@ class UH50Reader : public Component, public UARTDevice, public CustomAPIDevice {
                ESP_LOGW("readTelegram", "read_array() returned false, meter reading may be incomplete");
         ESP_LOGD("readTelegram", "Read %s", buffer);
 
-        if (len > 0) {
-          // end character reached
-          if (buffer[0] == '!') {
-            publishSensors(&parsed);
-            return;
-          }
-
-          char* obis_code = strtok_single(buffer, "(");
-          while (obis_code != NULL) {
-            char* value = strtok_single(NULL, "*)");
-            char* unit = strtok_single(NULL, "*)");
-            
-            if (value != NULL) {
-              //ESP_LOGI("data", "%s=[%s]", obis_code, value);
-              parseRow(&parsed, obis_code, value);
-              publish=true;
-            }
-            obis_code = strtok_single(NULL, "(");
-          }
-         
-        }
+	int count;
+	parse_obis(buffer, obisdata, &count);
+	print_parsed_data(obisdata, count);
+        publishSensors(obisdata, count);
 
         // clean buffer
         memset(buffer, 0, BUF_SIZE - 1);
 
       }
-
-      if (publish == true) {
-        ESP_LOGD("readTelegram", "Publishing sensor data");
-        publishSensors(&parsed);
-      }
     }
-
 };

--- a/uh50reader.yaml
+++ b/uh50reader.yaml
@@ -56,16 +56,53 @@ sensor:
       App.register_component(meter_sensor);
       return {
         meter_sensor->cumulativeActiveImport,
-        meter_sensor->cumulativeVolume
+        meter_sensor->cumulativeVolume,
+        meter_sensor->currentPower,
+        meter_sensor->flowRate,
+        meter_sensor->temperatureFlow,
+        meter_sensor->temperatureReturn,
+        meter_sensor->temperatureDiff
       };
     sensors:
-    - name: "Cumulative Active Import"
-      id: "heating_cumulative_active_import"
-      unit_of_measurement: kWh
-      accuracy_decimals: 2
+    - name: "UH50 Cumulative Active Import"
+      id: "uh50_cumulative_active_import"
+      unit_of_measurement: MWh
+      accuracy_decimals: 3
       state_class: "total_increasing"
       device_class: "energy"
-    - name: "Cumulative Volume"
-      id: "heating_cumulative_volume"
+    - name: "UH50 Cumulative Volume"
+      id: "uh50_cumulative_volume"
       unit_of_measurement: m3
-      accuracy_decimals: 6
+      accuracy_decimals: 3
+      state_class: "total_increasing"
+      device_class: "energy"
+    - name: "UH50 Current Power"
+      id: "uh50_current_power"
+      unit_of_measurement: kW
+      accuracy_decimals: 2
+      state_class: "measurement"
+      device_class: "energy"
+    - name: "UH50 Flow Rate"
+      id: "uh50_flow_rate"
+      unit_of_measurement: m3ph
+      accuracy_decimals: 3
+      state_class: "measurement"
+      device_class: "energy"
+    - name: "UH50 Flow Temperature"
+      id: "uh50_flow_temperature"
+      unit_of_measurement: C
+      accuracy_decimals: 2
+      state_class: "measurement"
+      device_class: "energy"
+    - name: "UH50 Return Temperature"
+      id: "uh50_return_temperature"
+      unit_of_measurement: C
+      accuracy_decimals: 2
+      state_class: "measurement"
+      device_class: "energy"
+    - name: "UH50 Diff Temperature"
+      id: "uh50_diff_temperature"
+      unit_of_measurement: C
+      accuracy_decimals: 2
+      state_class: "measurement"
+      device_class: "energy"

--- a/uh50reader.yaml
+++ b/uh50reader.yaml
@@ -4,6 +4,7 @@ esphome:
   #board d1_mini also works (wemos d1 mini)
   board: nodemcu 
   includes:
+    - obis.h
     - uh50reader.h
 
 wifi:


### PR DESCRIPTION
When UART receive pin is not connected to the Serial device, the reading fails.

This patch instead reads from UARTDevice from the configured rx-pin.

In my system, the whole telegram (about 1 kB) is already buffered and available to be read when the reading code is reached. I therefore increased the buffer size to hold the whole telegram with a read_array() call, instead of the previous line-based reading. This also implies the detection of "!" is not at the start of a line, so the publishing is triggered when no more data is available instead.

An alternative could be to do looped read() into the buffer until newline is detected, if the read_array() is not working sufficiently well. E.g. 

Having the full buffered read is however a preparation for the next step of parsing all OBIS objects for publishing.